### PR TITLE
Casting to int causes Exception in console

### DIFF
--- a/gii/GeneratorTrait.php
+++ b/gii/GeneratorTrait.php
@@ -96,7 +96,7 @@ trait GeneratorTrait
     protected function createNextPrefix($prefix)
     {
         try {
-            $uPrefix = (int)preg_replace('~[^0-9]~', '', $prefix);
+            $uPrefix = preg_replace('~[^0-9]~', '', $prefix);
             $uPrefix = \DateTime::createFromFormat('ymdHis', $uPrefix)->add(new \DateInterval('PT1S'))->format(
                     'ymd_His'
                 );


### PR DESCRIPTION
The cast to int causes this exception on my console (basic Yii install):

Exception 'Error' with message 'Call to a member function add() on boolean'

in /var/www/test/vendor/insolita/yii2-migration-generator/gii/GeneratorTrait.php:100

Removing the cast as in this request seems to do the job.