### PR TITLE
Fix for "Undefined index: fKeys" when using generation mode "All in one file"

### DIFF
--- a/gii/default_structure/mass.php
+++ b/gii/default_structure/mass.php
@@ -47,6 +47,7 @@ class <?= $migrationName ?> extends Migration
 <?php endforeach;?>
 <?php if (!empty($tableRelations) && is_array($tableRelations)) :?>
 <?php foreach ($tableRelations as $table) :?>
+<?php if (isset($table['fKeys']) === false) : continue; endif; ?>
 <?php foreach ($table['fKeys'] as $i => $rel) :?>
             $this->addForeignKey('fk_<?=$table['tableName']?>_<?=$rel['pk']?>','<?=$table['tableAlias']?>','<?=$rel['pk']?>','<?=$rel['ftable']?>','<?=$rel['fk']?>','<?=$fkProps['onDelete']?>','<?=$fkProps['onUpdate']?>');
 <?php endforeach;?>
@@ -65,6 +66,7 @@ class <?= $migrationName ?> extends Migration
         try{
 <?php if (!empty($tableRelations) && is_array($tableRelations)) :?>
 <?php foreach ($tableRelations as $table) :?>
+<?php if (isset($table['fKeys']) === false) : continue; endif; ?>
 <?php foreach ($table['fKeys'] as $i => $rel) :?>
             $this->dropForeignKey('fk_<?=$table['tableName']?>_<?=$rel['pk']?>', '<?=$table['tableAlias']?>');
 <?php endforeach;?>


### PR DESCRIPTION
When creating a migration and selecting "All in one file" as the generation mode, I get the following error:
```
PHP Notice – yii\base\ErrorException
Undefined index: fKeys
```
The error triggers on line 50 of gii/default_structure/mass.php
```php
50: <?php foreach ($table['fKeys'] as $i => $rel) :?>
```

I added a check to see if fKeys is defined before going into the loop. 
The check is added in safeUp() and safeDown() in mass.php

I am using MariaDB 10.1, so this is a possible reason why the error triggers.