### PR TITLE
fix json/other column type

### DIFF
--- a/resolver/BaseColumnResolver.php
+++ b/resolver/BaseColumnResolver.php
@@ -89,7 +89,7 @@ abstract class BaseColumnResolver implements IMigrationColumnResolver
 
             return call_user_func([$this, $columnTypeMethod], $column);
         } else {
-            $columnCategory = ArrayHelper::getValue($this->getColumnSchemaBuilder()->categoryMap, $column->type);
+            $columnCategory = ArrayHelper::getValue($this->getColumnSchemaBuilder()->categoryMap, $column->type) ?: 'other';
             \Yii::trace('try to call categoryMethod "resolve'.ucfirst($columnCategory).'"', __METHOD__);
 
             return call_user_func([$this, 'resolve'.ucfirst($columnCategory)], $column);


### PR DESCRIPTION
with json column time, $columnCategory is blank instead of 'other', causing stack trace. this defaults it to other and outputs correct json column in migration